### PR TITLE
{ARC} fix: update logic to sanitize cluster name for dc* objects

### DIFF
--- a/src/k8s-extension/azext_k8s_extension/partner_extensions/azuremonitormetrics/dc/defaults.py
+++ b/src/k8s-extension/azext_k8s_extension/partner_extensions/azuremonitormetrics/dc/defaults.py
@@ -13,10 +13,11 @@ from ..deaults import get_default_region
 # All DC* object names should end only in alpha numeric (after `length` trim)
 # DCE remove underscore from cluster name
 def sanitize_name(name, objtype, length):
+    name = name[0:length]
     length = length - 1
     if objtype == DC_TYPE.DCE:
         name = name.replace("_", "")
-    name = name[0:length]
+    name = ''.join(char for char in name if char.isalnum() or char == '-')
     lastIndexAlphaNumeric = len(name) - 1
     while ((name[lastIndexAlphaNumeric].isalnum() is False) and lastIndexAlphaNumeric > -1):
         lastIndexAlphaNumeric = lastIndexAlphaNumeric - 1


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az k8s-extension create --name azuremonitor-metrics -g kaveesharc -c kaveesharc -t connectedClusters --extension-type Microsoft.AzureMonitor.Containers.Metrics --configuration-settings azure-monitor-workspace-resource-id="{amw_id}" AzureMonitorMetrics.KubeStateMetrics.MetricAnnotationsAllowList="pods=[k8s-annotation-1,k8s-annotation-n]"`

The DC* objects can only container alphanumeric characters and '-' so updating the code to reflect it.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
